### PR TITLE
Winget migration

### DIFF
--- a/Setup.py
+++ b/Setup.py
@@ -54,11 +54,14 @@ else:
 
 ### Install Software ###
 ## 9P7KNL5RWT25 = Sysinternals
-Packages = ["putty.putty", "winscp.winscp", "Famatech.AdvancedIPScanner", "git.git", "Microsoft.VisualStudioCode", "vim.vim", "9P7KNL5RWT25", "JGraph.draw", "Microsoft.PowerToys", "videolan.vlc", "TeamViewer.TeamViewer", "VivaldiTechnologies.Vivaldi", "Rufus.Rufus", "xpipe-io.xpipe"]
+Packages = ["putty.putty", "winscp.winscp", "Famatech.AdvancedIPScanner", "git.git", "vim.vim", "9P7KNL5RWT25", "JGraph.draw", "Microsoft.PowerToys", "videolan.vlc", "TeamViewer.TeamViewer", "VivaldiTechnologies.Vivaldi", "Rufus.Rufus", "xpipe-io.xpipe"]
 
 for i in range(len(Packages)):
    temp = "winget install " + Packages[i] + " --accept-package-agreements --accept-source-agreements"
    system(temp)
+
+system("winget install Microsoft.VisualStudioCode --override \"/verysilent /suppressmsgboxes /mergetasks='!runcode,addcontextmenufiles,addcontextmenufolders,associatewithfiles,addtopath'\"")
+
 
 ## Choco Testing
 

--- a/Setup.py
+++ b/Setup.py
@@ -54,7 +54,7 @@ else:
 
 ### Install Software ###
 ## 9P7KNL5RWT25 = Sysinternals
-Packages = ["putty.putty", "winscp.winscp", "Famatech.AdvancedIPScanner", "git.git", "vim.vim", "9P7KNL5RWT25", "JGraph.draw", "Microsoft.PowerToys", "videolan.vlc", "Google.chrome", "Rufus.Rufus", "xpipe-io.xpipe"]
+Packages = ["putty.putty", "winscp.winscp", "Famatech.AdvancedIPScanner", "git.git", "vim.vim", "JGraph.draw", "Microsoft.PowerToys", "videolan.vlc", "Google.chrome", "Rufus.Rufus", "xpipe-io.xpipe"]
 
 for i in range(len(Packages)):
    temp = "winget install " + Packages[i] + " --accept-package-agreements --accept-source-agreements"

--- a/Setup.py
+++ b/Setup.py
@@ -54,7 +54,7 @@ else:
 
 ### Install Software ###
 ## 9P7KNL5RWT25 = Sysinternals
-Packages = ["putty.putty", "winscp.winscp", "Famatech.AdvancedIPScanner", "git.git", "vim.vim", "JGraph.draw", "Microsoft.PowerToys", "videolan.vlc", "Google.chrome", "Rufus.Rufus", "xpipe-io.xpipe", "joplin.joplin", "tailscale.tailscale", "nextcloud.nextclouddesktop", "JanDeDobbeleer.OhMyPosh", "Romanitho.Winget-AutoUpdate"]
+Packages = ["putty.putty", "winscp.winscp", "Famatech.AdvancedIPScanner", "git.git", "vim.vim", "JGraph.draw", "Microsoft.PowerToys", "videolan.vlc", "Google.chrome", "Rufus.Rufus", "xpipe-io.xpipe", "joplin.joplin", "tailscale.tailscale", "nextcloud.nextclouddesktop", "JanDeDobbeleer.OhMyPosh", "Romanitho.Winget-AutoUpdate", "ONLYOFFICE.DesktopEditors", "AutoHotkey.AutoHotkey", "Apple.iTunes"]
 
 for i in range(len(Packages)):
    temp = "winget install " + Packages[i] + " --accept-package-agreements --accept-source-agreements"

--- a/Setup.py
+++ b/Setup.py
@@ -54,21 +54,21 @@ else:
 
 ### Install Software ###
 ## 9P7KNL5RWT25 = Sysinternals
-# Packages = ["Google.Chrome", "putty.putty", "winscp.winscp", "Famatech.AdvancedIPScanner", "git.git", "Microsoft.VisualStudioCode", "vim.vim", "9P7KNL5RWT25", "JGraph.draw", "Microsoft.PowerToys", "google.drive", "videolan.vlc", "gerardog.gsudo", "TeamViewer.TeamViewer", "RubyInstallerTeam.RubyWithDevKit.3.1"]
+Packages = ["putty.putty", "winscp.winscp", "Famatech.AdvancedIPScanner", "git.git", "Microsoft.VisualStudioCode", "vim.vim", "9P7KNL5RWT25", "JGraph.draw", "Microsoft.PowerToys", "videolan.vlc", "TeamViewer.TeamViewer", "VivaldiTechnologies.Vivaldi", "Rufus.Rufus", "xpipe-io.xpipe"]
 
-# for i in range(len(Packages)):
-#    temp = "winget install " + Packages[i] + " --accept-package-agreements"
-#    system(temp)
+for i in range(len(Packages)):
+   temp = "winget install " + Packages[i] + " --accept-package-agreements --accept-source-agreements"
+   system(temp)
 
 ## Choco Testing
 
-Packages = ["putty", "winscp", "advanced-ip-scanner", "git", "vscode", "vim", "drawio", "PowerToys", "vlc", "tailscale", "onlyoffice", "nextcloud-client", "rufus", "Vivaldi", "xpipe"]
-
-for i in range(len(Packages)):
-    temp = "choco install " + Packages[i] + " -y"
-    system(temp)
-
-system("winget install 9P7KNL5RWT25 --accept-package-agreements")
+# Packages = ["putty", "winscp", "advanced-ip-scanner", "git", "vscode", "vim", "drawio", "PowerToys", "vlc", "tailscale", "onlyoffice", "nextcloud-client", "rufus", "Vivaldi", "xpipe"]
+# 
+# for i in range(len(Packages)):
+#     temp = "choco install " + Packages[i] + " -y"
+#     system(temp)
+# 
+# system("winget install 9P7KNL5RWT25 --accept-package-agreements")
 
 
 # Enable NFS Support

--- a/Setup.py
+++ b/Setup.py
@@ -54,7 +54,7 @@ else:
 
 ### Install Software ###
 ## 9P7KNL5RWT25 = Sysinternals
-Packages = ["putty.putty", "winscp.winscp", "Famatech.AdvancedIPScanner", "git.git", "vim.vim", "JGraph.draw", "Microsoft.PowerToys", "videolan.vlc", "Google.chrome", "Rufus.Rufus", "xpipe-io.xpipe", "joplin.joplin", "tailscale.tailscale", "nextcloud.nextclouddesktop", "JanDeDobbeleer.OhMyPosh"]
+Packages = ["putty.putty", "winscp.winscp", "Famatech.AdvancedIPScanner", "git.git", "vim.vim", "JGraph.draw", "Microsoft.PowerToys", "videolan.vlc", "Google.chrome", "Rufus.Rufus", "xpipe-io.xpipe", "joplin.joplin", "tailscale.tailscale", "nextcloud.nextclouddesktop", "JanDeDobbeleer.OhMyPosh", "Romanitho.Winget-AutoUpdate"]
 
 for i in range(len(Packages)):
    temp = "winget install " + Packages[i] + " --accept-package-agreements --accept-source-agreements"

--- a/Setup.py
+++ b/Setup.py
@@ -54,7 +54,7 @@ else:
 
 ### Install Software ###
 ## 9P7KNL5RWT25 = Sysinternals
-Packages = ["putty.putty", "winscp.winscp", "Famatech.AdvancedIPScanner", "git.git", "vim.vim", "JGraph.draw", "Microsoft.PowerToys", "videolan.vlc", "Google.chrome", "Rufus.Rufus", "xpipe-io.xpipe"]
+Packages = ["putty.putty", "winscp.winscp", "Famatech.AdvancedIPScanner", "git.git", "vim.vim", "JGraph.draw", "Microsoft.PowerToys", "videolan.vlc", "Google.chrome", "Rufus.Rufus", "xpipe-io.xpipe", "joplin.joplin", "tailscale.tailscale", "nextcloud.nextclouddesktop", "JanDeDobbeleer.OhMyPosh"]
 
 for i in range(len(Packages)):
    temp = "winget install " + Packages[i] + " --accept-package-agreements --accept-source-agreements"

--- a/Setup.py
+++ b/Setup.py
@@ -54,7 +54,7 @@ else:
 
 ### Install Software ###
 ## 9P7KNL5RWT25 = Sysinternals
-Packages = ["putty.putty", "winscp.winscp", "Famatech.AdvancedIPScanner", "git.git", "vim.vim", "9P7KNL5RWT25", "JGraph.draw", "Microsoft.PowerToys", "videolan.vlc", "TeamViewer.TeamViewer", "VivaldiTechnologies.Vivaldi", "Rufus.Rufus", "xpipe-io.xpipe"]
+Packages = ["putty.putty", "winscp.winscp", "Famatech.AdvancedIPScanner", "git.git", "vim.vim", "9P7KNL5RWT25", "JGraph.draw", "Microsoft.PowerToys", "videolan.vlc", "Google.chrome", "Rufus.Rufus", "xpipe-io.xpipe"]
 
 for i in range(len(Packages)):
    temp = "winget install " + Packages[i] + " --accept-package-agreements --accept-source-agreements"


### PR DESCRIPTION
Migrate to Winget from Chocolety to allow a more seamless setup process without the need for additional dependencies now that the winget app catalog has grown large enough to support mass deployment